### PR TITLE
Fix parse error in film view

### DIFF
--- a/partials/film-view.php
+++ b/partials/film-view.php
@@ -13,7 +13,7 @@ $boxsetFilms = $pdo->prepare("
      ORDER BY year, title
 ");
 $boxsetFilms->execute(['parent' => $parentId]);
-$boxChildren = $boxsetFilms->fetchAll()
+$boxChildren = $boxsetFilms->fetchAll();
 
 ?>
 


### PR DESCRIPTION
## Summary
- fix missing semicolon when retrieving child films

## Testing
- `php -l partials/film-view.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed90b855c83238b7b00c7c36516c9